### PR TITLE
Added option to specify the query used to count the number of records

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Returns promise
   - `[customLabels]` {Object} - Developers can provide custom labels for manipulating the response data.
   - `[pagination]` {Boolean} - If `pagination` is set to false, it will return all docs without adding limit condition. (Default: True)
   - `[allowDiskUse]` {Bool} - To enable diskUse for bigger queries. (Default: False)
+  - `[counQuery]` {Object} - Aggregate Query used to count the resultant documents. Can be used for bigger queries. (Default: `aggregare-query`)
 * `[callback(err, result)]` - (Optional) If specified the callback is called once pagination results are retrieved or when an error has occurred.
 
 **Return value**
@@ -230,6 +231,29 @@ Book.aggregatePaginate.options = {
   limit: 20
 };
 
+```
+
+### Using `countQuery`
+
+```javascript
+// Define your aggregate query.
+var aggregate = Model.aggregate();
+
+// Define the count aggregate query. Can be different from `aggregate`
+var countAggregate = Model.aggregate();
+
+// Set the count aggregate query
+const options = {
+    countQuery: countAggregate
+};
+
+Model.aggregatePaginate(aggregate, options)
+	.then(function(result) {
+		// result
+	})
+	.catch(function(err){
+		console.log(err);
+	});
 ```
 
 ## License

--- a/lib/mongoose-aggregate-paginate.js
+++ b/lib/mongoose-aggregate-paginate.js
@@ -26,7 +26,8 @@ const defaultOptions = {
   projection: {},
   select: '',
   options: {},
-  pagination: true
+  pagination: true,
+  countQuery: {}
 };
 
 function aggregatePaginate(query, options, callback) {
@@ -81,7 +82,7 @@ function aggregatePaginate(query, options, callback) {
   const isPaginationEnabled = options.pagination === false ? false : true;
 
   const q = this.aggregate(query._pipeline);
-  const countQuery = this.aggregate(q._pipeline);
+  const countQuery = options.countQuery ? options.countQuery : this.aggregate(q._pipeline);
 
   if (q.hasOwnProperty('options')) {
     q.options = query.options;

--- a/lib/mongoose-aggregate-paginate.js
+++ b/lib/mongoose-aggregate-paginate.js
@@ -27,7 +27,7 @@ const defaultOptions = {
   select: '',
   options: {},
   pagination: true,
-  countQuery: {}
+  countQuery: null
 };
 
 function aggregatePaginate(query, options, callback) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -83,6 +83,43 @@ describe('mongoose-paginate', function () {
     });
   });
 
+  it('count query test', function () {
+    var query = {
+      title: {
+        $in: [/Book/i]
+      }
+    };
+    var aggregate = Book.aggregate([{
+      $match: query
+    }, {
+      $sort: {
+        date: 1
+      }
+    }]);
+    var options = {
+      limit: 10,
+      page: 5,
+      allowDiskUse: true,
+      countQuery: Book.aggregate([{
+        $match: query
+      }])
+    };
+    return Book.aggregatePaginate(aggregate, options).then((result) => {
+
+      expect(result.docs).to.have.length(10);
+      expect(result.docs[0].title).to.equal('Book #41');
+      expect(result.totalDocs).to.equal(100);
+      expect(result.limit).to.equal(10);
+      expect(result.page).to.equal(5);
+      expect(result.pagingCounter).to.equal(41);
+      expect(result.hasPrevPage).to.equal(true);
+      expect(result.hasNextPage).to.equal(true);
+      expect(result.prevPage).to.equal(4);
+      expect(result.nextPage).to.equal(6);
+      expect(result.totalPages).to.equal(10);
+    });
+  });
+
   describe('paginates', function () {
 
     it('with global limit and page', function () {
@@ -147,8 +184,6 @@ describe('mongoose-paginate', function () {
         nextPage: 'next',
         prevPage: 'prev',
         totalPages: 'pageCount',
-        hasPrevPage: 'hasPrev',
-        hasNextPage: 'hasNext',
         pagingCounter: 'pageCounter'
       };
 
@@ -173,7 +208,7 @@ describe('mongoose-paginate', function () {
         expect(result.pageCount).to.equal(5);
       });
     });
-	
+
 	it('with offset', function () {
 
       var aggregate = Book.aggregate([{
@@ -187,7 +222,7 @@ describe('mongoose-paginate', function () {
           date: 1
         }
       }])
-	  
+
 	  const myCustomLabels = {
         totalDocs: 'itemCount',
         docs: 'itemsList',
@@ -198,8 +233,6 @@ describe('mongoose-paginate', function () {
         nextPage: 'next',
         prevPage: 'prev',
         totalPages: 'pageCount',
-        hasPrevPage: 'hasPrev',
-        hasNextPage: 'hasNext',
         pagingCounter: 'pageCounter'
       };
 


### PR DESCRIPTION
Right now the aggregation pipeline uses the same pipeline for calculating the number of records. This can create a challenge when the aggregation is complicated and/or the number of matched records is too large. 

In such a scenario, using a custom count pipeline can help in processing the pagination much faster. I have got improvements in the order of 100 times in a query I required.

This PR allows creates an option to pass their own count pipeline.