### PR TITLE
Using $facet instead of two queries & adding paginateExec to Aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # mongoose-aggregate-paginate-v2
+
 [![npm version](https://img.shields.io/npm/v/mongoose-aggregate-paginate-v2.svg)](https://www.npmjs.com/package/mongoose-aggregate-paginate-v2)
 [![Build Status](https://travis-ci.com/aravindnc/mongoose-aggregate-paginate-v2.svg?branch=master)](https://travis-ci.com/aravindnc/mongoose-aggregate-paginate-v2)
 [![Dependency Status](https://david-dm.org/aravindnc/mongoose-aggregate-paginate-v2.svg)](https://david-dm.org/aravindnc/mongoose-aggregate-paginate-v2)
@@ -22,37 +23,41 @@ npm install mongoose-aggregate-paginate-v2
 Adding the plugin to a schema,
 
 ```js
-var mongoose = require('mongoose');
-var aggregatePaginate = require('mongoose-aggregate-paginate-v2');
+var mongoose = require("mongoose");
+var aggregatePaginate = require("mongoose-aggregate-paginate-v2");
 
-var mySchema = new mongoose.Schema({ 
-    /* your schema definition */ 
+var mySchema = new mongoose.Schema({
+  /* your schema definition */
 });
 
 mySchema.plugin(aggregatePaginate);
 
-var myModel = mongoose.model('SampleModel',  mySchema); 
-
+var myModel = mongoose.model("SampleModel", mySchema);
 ```
 
 and then use model `aggregatePaginate` method,
+
 ```js
 // as Promise
 
-var myModel = require('/models/samplemodel');
+var myModel = require("/models/samplemodel");
 
 const options = {
-    page: 1,
-    limit: 10
+  page: 1,
+  limit: 10,
 };
 
 var myAggregate = myModel.aggregate();
-myModel.aggregatePaginate(myAggregate, options).then(function(results){
-	console.log(results);
-}).catch(function(err){
-	console.log(err);
-})
+myModel
+  .aggregatePaginate(myAggregate, options)
+  .then(function (results) {
+    console.log(results);
+  })
+  .catch(function (err) {
+    console.log(err);
+  });
 ```
+
 ```js
 // as Callback
 
@@ -67,7 +72,26 @@ var myAggregate = myModel.aggregate();
 myModel.aggregatePaginate(myAggregate, options, function(err, results) {
 	if(err) {
 		console.err(err);
-	else { 
+	else {
+    	console.log(results);
+	}
+})
+```
+
+```js
+// Execute pagination from aggregate
+const myModel = require('/models/samplemodel');
+
+const options = {
+    page: 1,
+    limit: 10
+};
+
+const myAggregate = myModel.aggregate();
+myAggregate.paginateExec(options, function(err, results) {
+	if(err) {
+		console.err(err);
+	else {
     	console.log(results);
 	}
 })
@@ -79,8 +103,8 @@ Returns promise
 
 **Parameters**
 
-* `[aggregate-query]` {Object} - Aggregate Query criteria. [Documentation](https://docs.mongodb.com/manual/aggregation/)
-* `[options]` {Object}
+- `[aggregate-query]` {Object} - Aggregate Query criteria. [Documentation](https://docs.mongodb.com/manual/aggregation/)
+- `[options]` {Object}
   - `[sort]` {Object | String} - Sort order. [Documentation](http://mongoosejs.com/docs/api.html#query_Query-sort)
   - `[offset=0]` {Number} - Use `offset` or `page` to set skip position
   - `[page]` {Number} - Current Page (Defaut: 1)
@@ -89,22 +113,24 @@ Returns promise
   - `[pagination]` {Boolean} - If `pagination` is set to false, it will return all docs without adding limit condition. (Default: True)
   - `[allowDiskUse]` {Bool} - To enable diskUse for bigger queries. (Default: False)
   - `[countQuery]` {Object} - Aggregate Query used to count the resultant documents. Can be used for bigger queries. (Default: `aggregate-query`)
-* `[callback(err, result)]` - (Optional) If specified the callback is called once pagination results are retrieved or when an error has occurred.
+  - `[useFacet]` {Bool} - To use facet operator instead of using two queries. This is the new default. (Default: true)
+- `[callback(err, result)]` - (Optional) If specified the callback is called once pagination results are retrieved or when an error has occurred.
 
 **Return value**
 
 Promise fulfilled with object having properties:
-* `docs` {Array} - Array of documents
-* `totalDocs` {Number} - Total number of documents that match a query
-* `limit` {Number} - Limit that was used
-* `page` {Number} - Current page number 
-* `totalPages` {Number} - Total number of pages.
-* `offset` {Number} - Only if specified or default `page`/`offset` values were used
-* `hasPrevPage` {Bool} - Availability of prev page.
-* `hasNextPage` {Bool} - Availability of next page.
-* `prevPage` {Number} - Previous page number if available or NULL
-* `nextPage` {Number} - Next page number if available or NULL
-* `pagingCounter` {Number} - The starting sl. number of first document.
+
+- `docs` {Array} - Array of documents
+- `totalDocs` {Number} - Total number of documents that match a query
+- `limit` {Number} - Limit that was used
+- `page` {Number} - Current page number
+- `totalPages` {Number} - Total number of pages.
+- `offset` {Number} - Only if specified or default `page`/`offset` values were used
+- `hasPrevPage` {Bool} - Availability of prev page.
+- `hasNextPage` {Bool} - Availability of next page.
+- `prevPage` {Number} - Previous page number if available or NULL
+- `nextPage` {Number} - Next page number if available or NULL
+- `pagingCounter` {Number} - The starting sl. number of first document.
 
 Please note that the above properties can be renamed by setting customLabels attribute.
 
@@ -113,50 +139,50 @@ Please note that the above properties can be renamed by setting customLabels att
 #### Return first 10 documents from 100
 
 ```javascript
-
 const options = {
-    page: 1,
-    limit: 10
+  page: 1,
+  limit: 10,
 };
 
 // Define your aggregate.
 var aggregate = Model.aggregate();
 
 Model.aggregatePaginate(aggregate, options)
-	.then(function(result) {
-		// result.docs
-		// result.totalDocs = 100
-		// result.limit = 10
-		// result.page = 1
-		// result.totalPages = 10    
-		// result.hasNextPage = true
-		// result.nextPage = 2
-		// result.hasPrevPage = false
-		// result.prevPage = null
-	})
-	.catch(function(err){
-		console.log(err);
-	});
+  .then(function (result) {
+    // result.docs
+    // result.totalDocs = 100
+    // result.limit = 10
+    // result.page = 1
+    // result.totalPages = 10
+    // result.hasNextPage = true
+    // result.nextPage = 2
+    // result.hasPrevPage = false
+    // result.prevPage = null
+  })
+  .catch(function (err) {
+    console.log(err);
+  });
 ```
 
 ### With custom return labels
 
 Now developers can specify the return field names if they want. Below are the list of attributes whose name can be changed.
 
-* totalDocs
-* docs
-* limit
-* page
-* nextPage
-* prevPage
-* totalPages
-* hasNextPage
-* hasPrevPage
-* pagingCounter
+- totalDocs
+- docs
+- limit
+- page
+- nextPage
+- prevPage
+- totalPages
+- hasNextPage
+- hasPrevPage
+- pagingCounter
 
 You should pass the names of the properties you wish to changes using `customLabels` object in options. Labels are optional, you can pass the labels of what ever keys are you changing, others will use the default labels.
 
 Same query with custom labels
+
 ```javascript
 
 const myCustomLabels = {
@@ -201,11 +227,14 @@ Model.aggregatePaginate(aggregate, options, function(err, result) {
 ### Using `offset` and `limit`
 
 ```javascript
-Model.aggregatePaginate(aggregate, { offset: 30, limit: 10 }, function(err, result) {
-  // result
-});
+Model.aggregatePaginate(
+  aggregate,
+  { offset: 30, limit: 10 },
+  function (err, result) {
+    // result
+  }
+);
 ```
-
 
 ### Using `countQuery`
 
@@ -218,48 +247,48 @@ var countAggregate = Model.aggregate();
 
 // Set the count aggregate query
 const options = {
-    countQuery: countAggregate
+  countQuery: countAggregate,
 };
 
 Model.aggregatePaginate(aggregate, options)
-	.then(function(result) {
-		// result
-	})
-	.catch(function(err){
-		console.log(err);
-	});
+  .then(function (result) {
+    // result
+  })
+  .catch(function (err) {
+    console.log(err);
+  });
 ```
 
 ### Global Options
+
 If you want to set the pagination options globally across the model. Then you can do like below,
 
 ```js
-
-let mongooseAggregatePaginate = require('mongoose-aggregate-paginate-v2');
+let mongooseAggregatePaginate = require("mongoose-aggregate-paginate-v2");
 
 let BookSchema = new mongoose.Schema({
   title: String,
   date: Date,
   author: {
     type: mongoose.Schema.ObjectId,
-    ref: 'Author'
-  }
+    ref: "Author",
+  },
 });
 
 BookSchema.plugin(mongooseAggregatePaginate);
 
-let Book = mongoose.model('Book', BookSchema);
+let Book = mongoose.model("Book", BookSchema);
 
 // Like this.
 Book.aggregatePaginate.options = {
-  limit: 20
+  limit: 20,
 };
-
 ```
 
 ## Release Note
+
 v1.0.42 - Added optional `countQuery` parameter to specify separate count queries in case of bigger aggerate pipeline.
 
-
 ## License
+
 [MIT](LICENSE)

--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
-var aggregatePaginate = require('./lib/mongoose-aggregate-paginate')
+const mongoose = require("mongoose");
+const aggregatePaginate = require("./lib/mongoose-aggregate-paginate");
 
 /**
  * @param {Schema} schema
  */
 module.exports = function (schema) {
   schema.statics.aggregatePaginate = aggregatePaginate;
+
+  mongoose.Aggregate.prototype.paginateExec = function (options, cb) {
+    return this.model().aggregatePaginate(this, options, cb);
+  };
 };

--- a/lib/mongoose-aggregate-paginate.js
+++ b/lib/mongoose-aggregate-paginate.js
@@ -32,7 +32,7 @@ const defaultOptions = {
 
 function aggregatePaginate(query, options, callback) {
   options = {
-    useFacet: true,
+    useFacet: false,
     ...defaultOptions,
     ...aggregatePaginate.options,
     ...options,
@@ -86,13 +86,8 @@ function aggregatePaginate(query, options, callback) {
   const isPaginationEnabled = options.pagination === false ? false : true;
 
   const q = this.aggregate(query._pipeline);
-  const countQuery = options.countQuery
-    ? options.countQuery
-    : this.aggregate(q._pipeline);
-
   if (q.hasOwnProperty("options")) {
     q.options = query.options;
-    countQuery.options = query.options;
   }
 
   if (sort) {
@@ -101,11 +96,10 @@ function aggregatePaginate(query, options, callback) {
 
   if (allowDiskUse) {
     q.allowDiskUse(true);
-    countQuery.allowDiskUse(true);
   }
 
   let promise;
-  if (options.useFacet) {
+  if (options.useFacet && !options.countQuery) {
     const docsAggregate = this.aggregate().match({});
 
     if (isPaginationEnabled) {
@@ -119,6 +113,18 @@ function aggregatePaginate(query, options, callback) {
       })
       .then(([{ docs, count }]) => [docs, count]);
   } else {
+    const countQuery = options.countQuery
+      ? options.countQuery
+      : this.aggregate(q._pipeline);
+
+    if (q.hasOwnProperty("options")) {
+      countQuery.options = query.options;
+    }
+
+    if (allowDiskUse) {
+      countQuery.allowDiskUse(true);
+    }
+
     if (isPaginationEnabled) {
       q.skip(skip).limit(limit);
     }

--- a/lib/mongoose-aggregate-paginate.js
+++ b/lib/mongoose-aggregate-paginate.js
@@ -32,7 +32,7 @@ const defaultOptions = {
 
 function aggregatePaginate(query, options, callback) {
   options = {
-    useFacet: false,
+    useFacet: true,
     ...defaultOptions,
     ...aggregatePaginate.options,
     ...options,

--- a/lib/mongoose-aggregate-paginate.js
+++ b/lib/mongoose-aggregate-paginate.js
@@ -8,40 +8,41 @@
 
 const defaultOptions = {
   customLabels: {
-    totalDocs: 'totalDocs',
-    limit: 'limit',
-    page: 'page',
-    totalPages: 'totalPages',
-    docs: 'docs',
-    nextPage: 'nextPage',
-    prevPage: 'prevPage',
-    pagingCounter: 'pagingCounter',
-    hasPrevPage: 'hasPrevPage',
-    hasNextPage: 'hasNextPage'
+    totalDocs: "totalDocs",
+    limit: "limit",
+    page: "page",
+    totalPages: "totalPages",
+    docs: "docs",
+    nextPage: "nextPage",
+    prevPage: "prevPage",
+    pagingCounter: "pagingCounter",
+    hasPrevPage: "hasPrevPage",
+    hasNextPage: "hasNextPage",
   },
   collation: {},
   lean: false,
   leanWithId: true,
   limit: 10,
   projection: {},
-  select: '',
+  select: "",
   options: {},
   pagination: true,
-  countQuery: null
+  countQuery: null,
 };
 
 function aggregatePaginate(query, options, callback) {
   options = {
+    useFacet: true,
     ...defaultOptions,
     ...aggregatePaginate.options,
-    ...options
+    ...options,
   };
 
   query = query || {};
 
   const customLabels = {
     ...defaultOptions.customLabels,
-    ...options.customLabels
+    ...options.customLabels,
   };
 
   const defaultLimit = 10;
@@ -59,16 +60,19 @@ function aggregatePaginate(query, options, callback) {
   const labelPagingCounter = customLabels.pagingCounter;
 
   let page = parseInt(options.page || 1, 10) || 1;
-  let limit = parseInt(options.limit, 10) > 0 ? parseInt(options.limit, 10) : defaultLimit;
+  let limit =
+    parseInt(options.limit, 10) > 0
+      ? parseInt(options.limit, 10)
+      : defaultLimit;
 
   // const skip = (page - 1) * limit;
   let skip;
   let offset;
 
-  if (options.hasOwnProperty('offset')) {
+  if (options.hasOwnProperty("offset")) {
     offset = parseInt(options.offset, 10);
     skip = offset;
-  } else if (options.hasOwnProperty('page')) {
+  } else if (options.hasOwnProperty("page")) {
     page = parseInt(options.page, 10);
     skip = (page - 1) * limit;
   } else {
@@ -82,9 +86,11 @@ function aggregatePaginate(query, options, callback) {
   const isPaginationEnabled = options.pagination === false ? false : true;
 
   const q = this.aggregate(query._pipeline);
-  const countQuery = options.countQuery ? options.countQuery : this.aggregate(q._pipeline);
+  const countQuery = options.countQuery
+    ? options.countQuery
+    : this.aggregate(q._pipeline);
 
-  if (q.hasOwnProperty('options')) {
+  if (q.hasOwnProperty("options")) {
     q.options = query.options;
     countQuery.options = query.options;
   }
@@ -94,26 +100,44 @@ function aggregatePaginate(query, options, callback) {
   }
 
   if (allowDiskUse) {
-    q.allowDiskUse(true)
-    countQuery.allowDiskUse(true)
+    q.allowDiskUse(true);
+    countQuery.allowDiskUse(true);
   }
 
-  if (isPaginationEnabled) {
-    q.skip(skip).limit(limit);
-  }
+  let promise;
+  if (options.useFacet) {
+    const docsAggregate = this.aggregate().match({});
 
-  return Promise.all([
+    if (isPaginationEnabled) {
+      docsAggregate.skip(skip).limit(limit);
+    }
 
+    promise = q
+      .facet({
+        docs: docsAggregate._pipeline,
+        count: [{ $count: "count" }],
+      })
+      .then(([{ docs, count }]) => [docs, count]);
+  } else {
+    if (isPaginationEnabled) {
+      q.skip(skip).limit(limit);
+    }
+
+    promise = Promise.all([
       q.exec(),
-      countQuery.group({
-        _id: null,
-        count: {
-          $sum: 1
-        }
-      }).exec()
-    ])
-    .then(function (values) {
+      countQuery
+        .group({
+          _id: null,
+          count: {
+            $sum: 1,
+          },
+        })
+        .exec(),
+    ]);
+  }
 
+  return promise
+    .then(function (values) {
       var count = values[1][0] ? values[1][0].count : 0;
 
       if (isPaginationEnabled === false) {
@@ -121,21 +145,20 @@ function aggregatePaginate(query, options, callback) {
         page = 1;
       }
 
-      var pages = Math.ceil(count / limit) || 1;
+      const pages = Math.ceil(count / limit) || 1;
 
-      var result = {
+      const result = {
         [labelDocs]: values[0],
         [labelTotal]: count,
         [labelLimit]: limit,
         [labelPage]: page,
         [labelTotalPages]: pages,
-        [labelPagingCounter]: ((page - 1) * limit) + 1,
+        [labelPagingCounter]: (page - 1) * limit + 1,
         [labelHasPrevPage]: false,
-        [labelHasNextPage]: false
+        [labelHasNextPage]: false,
       };
 
-      if (typeof offset !== 'undefined') {
-
+      if (typeof offset !== "undefined") {
         page = Math.ceil((offset + 1) / limit);
 
         result.offset = offset;
@@ -146,7 +169,7 @@ function aggregatePaginate(query, options, callback) {
       // Set prev page
       if (page > 1) {
         result[labelHasPrevPage] = true;
-        result[labelPrevPage] = (page - 1);
+        result[labelPrevPage] = page - 1;
       } else {
         result[labelPrevPage] = null;
       }
@@ -154,24 +177,23 @@ function aggregatePaginate(query, options, callback) {
       // Set next page
       if (page < pages) {
         result[labelHasNextPage] = true;
-        result[labelNextPage] = (page + 1);
+        result[labelNextPage] = page + 1;
       } else {
         result[labelNextPage] = null;
       }
 
-      if (typeof callback === 'function') {
+      if (typeof callback === "function") {
         return callback(null, result);
       }
 
       return Promise.resolve(result);
-
     })
     .catch(function (reject) {
-      if (typeof callback === 'function') {
-        return callback(reject)
+      if (typeof callback === "function") {
+        return callback(reject);
       }
-      return Promise.reject(reject)
-    })
+      return Promise.reject(reject);
+    });
 }
 
 /**

--- a/lib/mongoose-aggregate-paginate.js
+++ b/lib/mongoose-aggregate-paginate.js
@@ -196,11 +196,4 @@ function aggregatePaginate(query, options, callback) {
     });
 }
 
-/**
- * @param {Schema} schema
- */
-module.exports = (schema) => {
-  schema.statics.aggregatePaginate = aggregatePaginate;
-};
-
 module.exports = aggregatePaginate;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,31 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@types/bson": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
+			"integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/mongodb": {
+			"version": "3.6.15",
+			"resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.15.tgz",
+			"integrity": "sha512-66o54Py66NyYxb9/za2dH01ZsD1PCbPdJeys1VMhlitE4lrbmF3akpICzVmzkaiL6byCeG8iClfhD5ThZGu8+A==",
+			"dev": true,
+			"requires": {
+				"@types/bson": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/node": {
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.1.tgz",
+			"integrity": "sha512-weaeiP4UF4XgF++3rpQhpIJWsCTS4QJw5gvBhQu6cFIxTwyxWIe3xbnrY/o2lTCQ0lsdb8YIUDUvLR4Vuz5rbw==",
+			"dev": true
+		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -1042,6 +1067,16 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
+		"bl": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+			"integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.3.5",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -1077,9 +1112,9 @@
 			"dev": true
 		},
 		"bson": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
-			"integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+			"integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
 			"dev": true
 		},
 		"cache-base": {
@@ -1248,8 +1283,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"debug": {
 			"version": "2.6.9",
@@ -1334,6 +1368,12 @@
 					"optional": true
 				}
 			}
+		},
+		"denque": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+			"integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
+			"dev": true
 		},
 		"detect-indent": {
 			"version": "4.0.0",
@@ -2390,8 +2430,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
@@ -2422,9 +2461,9 @@
 			"dev": true
 		},
 		"kareem": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
-			"integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
+			"integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ==",
 			"dev": true
 		},
 		"kind-of": {
@@ -2438,9 +2477,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.19",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
 		"loose-envify": {
@@ -2544,12 +2583,20 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
+				"minimist": "^1.2.5"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				}
 			}
 		},
 		"mocha": {
@@ -2600,6 +2647,15 @@
 						"path-is-absolute": "^1.0.0"
 					}
 				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
 				"supports-color": {
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -2612,33 +2668,36 @@
 			}
 		},
 		"mongodb": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.4.1.tgz",
-			"integrity": "sha512-juqt5/Z42J4DcE7tG7UdVaTKmUC6zinF4yioPfpeOSNBieWSK6qCY+0tfGQcHLKrauWPDdMZVROHJOa8q2pWsA==",
+			"version": "3.6.6",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.6.tgz",
+			"integrity": "sha512-WlirMiuV1UPbej5JeCMqE93JRfZ/ZzqE7nJTwP85XzjAF4rRSeq2bGCb1cjfoHLOF06+HxADaPGqT0g3SbVT1w==",
 			"dev": true,
 			"requires": {
-				"bson": "^1.1.1",
-				"require_optional": "^1.0.1",
+				"bl": "^2.2.1",
+				"bson": "^1.1.4",
+				"denque": "^1.4.1",
+				"optional-require": "^1.0.2",
 				"safe-buffer": "^5.1.2",
 				"saslprep": "^1.0.0"
 			}
 		},
 		"mongoose": {
-			"version": "5.8.9",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.8.9.tgz",
-			"integrity": "sha512-gRazoLTQ0yuv4bk2z+nZEarKCyJ7WilFBkgrRqpOczUZUhk3i/FCe0rp8Mjc87dGXaHx54j8AjPJ0UKqJDXWMA==",
+			"version": "5.12.10",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.12.10.tgz",
+			"integrity": "sha512-/VmFFEACH2yiuPcJoBjOzVTXozBhCeminVbWI8mxiZwvgCbNu9PQrIABIgeCJncnZH8VT4G7s2IXO5FySxF1XA==",
 			"dev": true,
 			"requires": {
-				"bson": "~1.1.1",
-				"kareem": "2.3.1",
-				"mongodb": "3.4.1",
+				"@types/mongodb": "^3.5.27",
+				"bson": "^1.1.4",
+				"kareem": "2.3.2",
+				"mongodb": "3.6.6",
 				"mongoose-legacy-pluralize": "1.0.2",
-				"mpath": "0.6.0",
-				"mquery": "3.2.2",
+				"mpath": "0.8.3",
+				"mquery": "3.2.5",
 				"ms": "2.1.2",
 				"regexp-clone": "1.0.0",
-				"safe-buffer": "5.1.2",
-				"sift": "7.0.1",
+				"safe-buffer": "5.2.1",
+				"sift": "13.5.2",
 				"sliced": "1.0.1"
 			},
 			"dependencies": {
@@ -2646,6 +2705,12 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 					"dev": true
 				}
 			}
@@ -2657,15 +2722,15 @@
 			"dev": true
 		},
 		"mpath": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",
-			"integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw==",
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.3.tgz",
+			"integrity": "sha512-eb9rRvhDltXVNL6Fxd2zM9D4vKBxjVVQNLNijlj7uoXUy19zNDsIif5zR+pWmPCWNKwAtqyo4JveQm4nfD5+eA==",
 			"dev": true
 		},
 		"mquery": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.2.tgz",
-			"integrity": "sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
+			"integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
 			"dev": true,
 			"requires": {
 				"bluebird": "3.5.1",
@@ -2846,6 +2911,12 @@
 				"wrappy": "1"
 			}
 		},
+		"optional-require": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
+			"integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
+			"dev": true
+		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -2925,8 +2996,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"randomatic": {
 			"version": "3.1.1",
@@ -2961,7 +3031,6 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -3400,22 +3469,6 @@
 				"is-finite": "^1.0.0"
 			}
 		},
-		"require_optional": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-			"dev": true,
-			"requires": {
-				"resolve-from": "^2.0.0",
-				"semver": "^5.1.0"
-			}
-		},
-		"resolve-from": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-			"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-			"dev": true
-		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -3456,12 +3509,6 @@
 				"sparse-bitfield": "^3.0.3"
 			}
 		},
-		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
-		},
 		"set-value": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -3488,9 +3535,9 @@
 			}
 		},
 		"sift": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
-			"integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
+			"integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA==",
 			"dev": true
 		},
 		"slash": {
@@ -3708,7 +3755,6 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -3880,8 +3926,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,50 +1,50 @@
 {
-	"name": "mongoose-aggregate-paginate-v2",
-	"version": "1.0.42",
-	"description": "A cursor based custom aggregate pagination library for Mongoose with customizable labels.",
-	"main": "index.js",
-	"scripts": {
-		"test": "./node_modules/.bin/mocha tests/*.js -R spec --ui bdd --timeout 5000"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/aravindnc/mongoose-aggregate-paginate-v2.git"
-	},
-	"keywords": [
-		"aggregate",
-		"aggregate-paginate",
-		"aggregate-pagination",
-		"mongoose-aggregate",
-		"mongoose",
-		"pagination",
-		"plugin",
-		"mongodb",
-		"paginate",
-		"paging",
-		"next",
-		"prev",
-		"nextpage",
-		"prevpage",
-		"total",
-		"paginator",
-		"plugin"
-	],
-	"author": "Aravind NC <aravind_n_c@yahoo.co.in> (http://aravindnc.com)",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/aravindnc/mongoose-aggregate-paginate-v2/issues"
-	},
-	"homepage": "https://github.com/aravindnc/mongoose-aggregate-paginate-v2#readme",
-	"dependencies": {},
-	"devDependencies": {
-		"babel-cli": "^6.26.0",
-		"babel-preset-es2015": "^6.24.1",
-		"babel-preset-stage-0": "^6.24.1",
-		"chai": "^4.2.0",
-		"mocha": "^5.2.0",
-		"mongoose": "^5.12.10"
-	},
-	"engines": {
-		"node": ">=4.0.0"
-	}
+  "name": "mongoose-aggregate-paginate-v2",
+  "version": "1.0.43",
+  "description": "A cursor based custom aggregate pagination library for Mongoose with customizable labels.",
+  "main": "index.js",
+  "scripts": {
+    "test": "./node_modules/.bin/mocha tests/*.js -R spec --ui bdd --timeout 5000"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aravindnc/mongoose-aggregate-paginate-v2.git"
+  },
+  "keywords": [
+    "aggregate",
+    "aggregate-paginate",
+    "aggregate-pagination",
+    "mongoose-aggregate",
+    "mongoose",
+    "pagination",
+    "plugin",
+    "mongodb",
+    "paginate",
+    "paging",
+    "next",
+    "prev",
+    "nextpage",
+    "prevpage",
+    "total",
+    "paginator",
+    "plugin"
+  ],
+  "author": "Aravind NC <aravind_n_c@yahoo.co.in> (http://aravindnc.com)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/aravindnc/mongoose-aggregate-paginate-v2/issues"
+  },
+  "homepage": "https://github.com/aravindnc/mongoose-aggregate-paginate-v2#readme",
+  "dependencies": {},
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
+    "chai": "^4.2.0",
+    "mocha": "^5.2.0",
+    "mongoose": "^5.12.10"
+  },
+  "engines": {
+    "node": ">=4.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
 		"babel-cli": "^6.26.0",
 		"babel-preset-es2015": "^6.24.1",
 		"babel-preset-stage-0": "^6.24.1",
+		"chai": "^4.2.0",
 		"mocha": "^5.2.0",
-		"mongoose": "^5.2.4",
-		"chai": "^4.2.0"
+		"mongoose": "^5.12.10"
 	},
 	"engines": {
 		"node": ">=4.0.0"

--- a/tests/index.js
+++ b/tests/index.js
@@ -65,7 +65,8 @@ describe("mongoose-paginate", function () {
       },
     ]);
 
-    let promise = Book.aggregatePaginate(aggregate, {});
+    let promise = aggregate.paginateExec({});
+    // let promise = Book.aggregatePaginate(aggregate, {});
     expect(promise.then).to.be.an.instanceof(Function);
   });
 
@@ -79,7 +80,8 @@ describe("mongoose-paginate", function () {
         },
       },
     ]);
-    Book.aggregatePaginate(aggregate, {}, function (err, result) {
+
+    aggregate.paginateExec({}, function (err, result) {
       expect(err).to.be.null;
       expect(result).to.be.an.instanceOf(Object);
       done();

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,31 +1,30 @@
-'use strict';
+"use strict";
 
-let mongoose = require('mongoose');
-let expect = require('chai').expect;
-let mongooseAggregatePaginate = require('../index');
+let mongoose = require("mongoose");
+let expect = require("chai").expect;
+let mongooseAggregatePaginate = require("../index");
 
-let MONGO_URI = 'mongodb://127.0.0.1/mongoose_paginate_test';
+let MONGO_URI = "mongodb://127.0.0.1/mongoose_paginate_test";
 
 let AuthorSchema = new mongoose.Schema({
-  name: String
+  name: String,
 });
-let Author = mongoose.model('Author', AuthorSchema);
+let Author = mongoose.model("Author", AuthorSchema);
 
 let BookSchema = new mongoose.Schema({
   title: String,
   date: Date,
   author: {
     type: mongoose.Schema.ObjectId,
-    ref: 'Author'
-  }
+    ref: "Author",
+  },
 });
 
 BookSchema.plugin(mongooseAggregatePaginate);
 
-let Book = mongoose.model('Book', BookSchema);
+let Book = mongoose.model("Book", BookSchema);
 
-describe('mongoose-paginate', function () {
-
+describe("mongoose-paginate", function () {
   before(function (done) {
     mongoose.connect(MONGO_URI, done);
   });
@@ -35,16 +34,17 @@ describe('mongoose-paginate', function () {
   });
 
   before(function () {
-    let book, books = [];
+    let book,
+      books = [];
     let date = new Date();
     return Author.create({
-      name: 'Arthur Conan Doyle'
+      name: "Arthur Conan Doyle",
     }).then(function (author) {
       for (let i = 1; i <= 100; i++) {
         book = new Book({
-          title: 'Book #' + i,
+          title: "Book #" + i,
           date: new Date(date.getTime() + i),
-          author: author._id
+          author: author._id,
         });
         books.push(book);
       }
@@ -52,30 +52,33 @@ describe('mongoose-paginate', function () {
     });
   });
 
-  afterEach(function () {
+  afterEach(function () {});
 
-  });
+  it("promise return test", function () {
+    var aggregate = Book.aggregate([
+      {
+        $match: {
+          title: {
+            $in: [/Book/i],
+          },
+        },
+      },
+    ]);
 
-  it('promise return test', function () {
-    var aggregate = Book.aggregate([{
-      $match: {
-        title: {
-          $in: [/Book/i]
-        }
-      }
-    }])
     let promise = Book.aggregatePaginate(aggregate, {});
     expect(promise.then).to.be.an.instanceof(Function);
   });
 
-  it('callback test', function (done) {
-    var aggregate = Book.aggregate([{
-      $match: {
-        title: {
-          $in: [/Book/i]
-        }
-      }
-    }])
+  it("callback test", function (done) {
+    var aggregate = Book.aggregate([
+      {
+        $match: {
+          title: {
+            $in: [/Book/i],
+          },
+        },
+      },
+    ]);
     Book.aggregatePaginate(aggregate, {}, function (err, result) {
       expect(err).to.be.null;
       expect(result).to.be.an.instanceOf(Object);
@@ -83,31 +86,35 @@ describe('mongoose-paginate', function () {
     });
   });
 
-  it('count query test', function () {
+  it("count query test", function () {
     var query = {
       title: {
-        $in: [/Book/i]
-      }
+        $in: [/Book/i],
+      },
     };
-    var aggregate = Book.aggregate([{
-      $match: query
-    }, {
-      $sort: {
-        date: 1
-      }
-    }]);
+    var aggregate = Book.aggregate([
+      {
+        $match: query,
+      },
+      {
+        $sort: {
+          date: 1,
+        },
+      },
+    ]);
     var options = {
       limit: 10,
       page: 5,
       allowDiskUse: true,
-      countQuery: Book.aggregate([{
-        $match: query
-      }])
+      countQuery: Book.aggregate([
+        {
+          $match: query,
+        },
+      ]),
     };
     return Book.aggregatePaginate(aggregate, options).then((result) => {
-
       expect(result.docs).to.have.length(10);
-      expect(result.docs[0].title).to.equal('Book #41');
+      expect(result.docs[0].title).to.equal("Book #41");
       expect(result.totalDocs).to.equal(100);
       expect(result.limit).to.equal(10);
       expect(result.page).to.equal(5);
@@ -120,34 +127,34 @@ describe('mongoose-paginate', function () {
     });
   });
 
-  describe('paginates', function () {
-
-    it('with global limit and page', function () {
-
+  describe("paginates", function () {
+    it("with global limit and page", function () {
       Book.aggregatePaginate.options = {
-        limit: 20
+        limit: 20,
       };
 
-      var aggregate = Book.aggregate([{
-        $match: {
-          title: {
-            $in: [/Book/i]
-          }
-        }
-      }, {
-        $sort: {
-          date: 1
-        }
-      }])
+      var aggregate = Book.aggregate([
+        {
+          $match: {
+            title: {
+              $in: [/Book/i],
+            },
+          },
+        },
+        {
+          $sort: {
+            date: 1,
+          },
+        },
+      ]);
       var options = {
         limit: 10,
         page: 5,
-        allowDiskUse: true
+        allowDiskUse: true,
       };
       return Book.aggregatePaginate(aggregate, options).then((result) => {
-
         expect(result.docs).to.have.length(10);
-        expect(result.docs[0].title).to.equal('Book #41');
+        expect(result.docs[0].title).to.equal("Book #41");
         expect(result.totalDocs).to.equal(100);
         expect(result.limit).to.equal(10);
         expect(result.page).to.equal(5);
@@ -160,43 +167,43 @@ describe('mongoose-paginate', function () {
       });
     });
 
-    it('with custom labels', function () {
-
-      var aggregate = Book.aggregate([{
-        $match: {
-          title: {
-            $in: [/Book/i]
-          }
-        }
-      }, {
-        $sort: {
-          date: 1
-        }
-      }])
+    it("with custom labels", function () {
+      var aggregate = Book.aggregate([
+        {
+          $match: {
+            title: {
+              $in: [/Book/i],
+            },
+          },
+        },
+        {
+          $sort: {
+            date: 1,
+          },
+        },
+      ]);
 
       const myCustomLabels = {
-        totalDocs: 'itemCount',
-        docs: 'itemsList',
-        limit: 'perPage',
-        page: 'currentPage',
-        hasNextPage: 'hasNext',
-        hasPrevPage: 'hasPrev',
-        nextPage: 'next',
-        prevPage: 'prev',
-        totalPages: 'pageCount',
-        pagingCounter: 'pageCounter'
+        totalDocs: "itemCount",
+        docs: "itemsList",
+        limit: "perPage",
+        page: "currentPage",
+        hasNextPage: "hasNext",
+        hasPrevPage: "hasPrev",
+        nextPage: "next",
+        prevPage: "prev",
+        totalPages: "pageCount",
+        pagingCounter: "pageCounter",
       };
 
       var options = {
         // limit: 10,
         page: 5,
-        customLabels: myCustomLabels
-
+        customLabels: myCustomLabels,
       };
       return Book.aggregatePaginate(aggregate, options).then((result) => {
-
         expect(result.itemsList).to.have.length(20);
-        expect(result.itemsList[0].title).to.equal('Book #81');
+        expect(result.itemsList[0].title).to.equal("Book #81");
         expect(result.itemCount).to.equal(100);
         expect(result.perPage).to.equal(20);
         expect(result.currentPage).to.equal(5);
@@ -209,45 +216,44 @@ describe('mongoose-paginate', function () {
       });
     });
 
-	it('with offset', function () {
+    it("with offset", function () {
+      var aggregate = Book.aggregate([
+        {
+          $match: {
+            title: {
+              $in: [/Book/i],
+            },
+          },
+        },
+        {
+          $sort: {
+            date: 1,
+          },
+        },
+      ]);
 
-      var aggregate = Book.aggregate([{
-        $match: {
-          title: {
-            $in: [/Book/i]
-          }
-        }
-      }, {
-        $sort: {
-          date: 1
-        }
-      }])
-
-	  const myCustomLabels = {
-        totalDocs: 'itemCount',
-        docs: 'itemsList',
-        limit: 'perPage',
-        page: 'currentPage',
-        hasNextPage: 'hasNext',
-        hasPrevPage: 'hasPrev',
-        nextPage: 'next',
-        prevPage: 'prev',
-        totalPages: 'pageCount',
-        pagingCounter: 'pageCounter'
+      const myCustomLabels = {
+        totalDocs: "itemCount",
+        docs: "itemsList",
+        limit: "perPage",
+        page: "currentPage",
+        hasNextPage: "hasNext",
+        hasPrevPage: "hasPrev",
+        nextPage: "next",
+        prevPage: "prev",
+        totalPages: "pageCount",
+        pagingCounter: "pageCounter",
       };
 
       var options = {
         // limit: 10,
         offset: 80,
-        customLabels: myCustomLabels
-
+        customLabels: myCustomLabels,
       };
 
-
       return Book.aggregatePaginate(aggregate, options).then((result) => {
-
         expect(result.itemsList).to.have.length(20);
-        expect(result.itemsList[0].title).to.equal('Book #81');
+        expect(result.itemsList[0].title).to.equal("Book #81");
         expect(result.itemCount).to.equal(100);
         expect(result.perPage).to.equal(20);
         expect(result.currentPage).to.equal(5);
@@ -259,7 +265,6 @@ describe('mongoose-paginate', function () {
         expect(result.pageCount).to.equal(5);
       });
     });
-
   });
 
   after(function (done) {
@@ -269,5 +274,4 @@ describe('mongoose-paginate', function () {
   after(function (done) {
     mongoose.disconnect(done);
   });
-
 });


### PR DESCRIPTION
This pull request contains two features:

- `$facet` operator is now being used by default instead of executing two queries. To disable, pass `useFacet: false` to the options.
- Mongoose's `Aggregate`  is extended and paginate can now be called directly using `aggregate.paginateExec(options, [cb])`.

If `countQuery` and `useFacet`, two queries will still be executed, and facet will be ignored.

**Breaking Changes:**
- [$facet](https://docs.mongodb.com/manual/reference/operator/aggregation/facet/) and [$count](https://docs.mongodb.com/manual/reference/operator/aggregation/count/) require mongo 3.4+
- `$facet` is now used by default.