### PR TITLE
Feature/support for prepagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,42 @@ Model.aggregatePaginate(aggregate, options)
   });
 ```
 
+### Using `prepagination`
+
+This allows you to paginate the result at a given placeholder stage in a pipeline rather than at the end which is the default behavior. This can be useful when you have a large dataset and you want to paginate before carrying out expensive operations such as `$lookup` or `$unwind`.
+
+```javascript
+// Define your pipeline
+const pipeline = [
+  {
+    $match: {
+      status: "active"
+    }
+  },
+  {
+    $sort: {
+      date: -1
+    }
+  },
+  "__PREPAGINATE__",
+  {
+    $lookup: {
+      from: "authors",
+      localField: "author",
+      foreignField: "_id",
+      as: "author"
+    }
+  }
+];
+Model.aggregatePaginate(pipeline, options)
+  .then(function (result) {
+    // result
+  })
+  .catch(function (err) {
+    console.log(err);
+  });
+```
+
 ### Global Options
 
 If you want to set the pagination options globally across the model. Then you can do like below,

--- a/index.js
+++ b/index.js
@@ -13,3 +13,5 @@ module.exports = function (schema) {
 };
 
 module.exports.aggregatePaginate = aggregatePaginate;
+
+module.exports.PREPAGINATION_PLACEHOLDER = aggregatePaginate.PREPAGINATION_PLACEHOLDER;

--- a/lib/mongoose-aggregate-paginate.js
+++ b/lib/mongoose-aggregate-paginate.js
@@ -32,6 +32,8 @@ const defaultOptions = {
   useFacet: true,
 };
 
+const PREPAGINATION_PLACEHOLDER = "__PREPAGINATE__";
+
 function aggregatePaginate(query, options, callback) {
   options = {
     ...defaultOptions,
@@ -39,7 +41,7 @@ function aggregatePaginate(query, options, callback) {
     ...options,
   };
 
-  query = query || {};
+  const pipeline = Array.isArray(query) ? query : query._pipeline;
 
   const customLabels = {
     ...defaultOptions.customLabels,
@@ -87,49 +89,62 @@ function aggregatePaginate(query, options, callback) {
   const allowDiskUse = options.allowDiskUse || false;
   const isPaginationEnabled = options.pagination === false ? false : true;
 
-  const q = this.aggregate(query._pipeline);
-  if (Object.prototype.hasOwnProperty.call(q, "options")) {
-    q.options = query.options;
-  }
+  const q = this.aggregate();
 
-  if (sort) {
-    q.sort(sort);
-  }
+  if (query.options) q.options = query.options;
 
   if (allowDiskUse) {
     q.allowDiskUse(true);
   }
 
-  let promise;
-  if (options.useFacet && !options.countQuery) {
-    const docsAggregate = this.aggregate().match({});
+  if (sort) {
+    pipeline.push({ $sort: sort });
+  }
+
+  function constructPipelines() {
+    let cleanedPipeline = pipeline.filter((stage) => stage !== PREPAGINATION_PLACEHOLDER);
+
+    const countPipeline = [...cleanedPipeline, { $count: "count" }];
 
     if (isPaginationEnabled) {
-      docsAggregate.skip(skip).limit(limit);
+      let foundPrepagination = false;
+      cleanedPipeline = pipeline.flatMap((stage) => {
+        if (stage === PREPAGINATION_PLACEHOLDER) {
+          foundPrepagination = true;
+          return [{ $skip: skip }, { $limit: limit }];
+        }
+        return stage;
+      });
+      if (!foundPrepagination) {
+        cleanedPipeline.push({ $skip: skip }, { $limit: limit });
+      }
     }
+    return [cleanedPipeline, countPipeline];
+  }
 
+
+  let promise;
+  if (options.useFacet && !options.countQuery) {
+    const [pipeline, countPipeline] = constructPipelines();
     promise = q
       .facet({
-        docs: docsAggregate._pipeline,
-        count: [{ $count: "count" }],
+        docs: pipeline,
+        count: countPipeline
       })
       .then(([{ docs, count }]) => [docs, count]);
   } else {
-    const countQuery = options.countQuery
-      ? options.countQuery
-      : this.aggregate(q._pipeline);
 
-    if (Object.prototype.hasOwnProperty.call(q, "options")) {
-      countQuery.options = query.options;
-    }
+    const [pipeline] = constructPipelines();
+
+    const countQuery = options.countQuery ? options.countQuery : this.aggregate(pipeline);
 
     if (allowDiskUse) {
       countQuery.allowDiskUse(true);
     }
 
-    if (isPaginationEnabled) {
-      q.skip(skip).limit(limit);
-    }
+    const q = this.aggregate(pipeline);
+
+    if (query.options) q.options = query.options;
 
     promise = Promise.all([
       q.exec(),
@@ -214,3 +229,5 @@ function aggregatePaginate(query, options, callback) {
 }
 
 module.exports = aggregatePaginate;
+
+module.exports.PREPAGINATION_PLACEHOLDER = PREPAGINATION_PLACEHOLDER;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "mongoose-aggregate-paginate-v2",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "A cursor based custom aggregate pagination library for Mongoose with customizable labels.",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "pretest": "npm run prepare",
     "test": "./node_modules/.bin/mocha tests/*.js -R spec --ui bdd --timeout 5000",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,88 @@
+//
+// Based on type declarations for mongoose-paginate-v2 1.3.
+//
+// Thanks to knyuwork <https://github.com/knyuwork>
+// and LiRen Tu <https://github.com/tuliren> for their contribution
+
+declare module "mongoose" {
+    interface CustomLabels<T = string | undefined | boolean> {
+        totalDocs?: T | undefined;
+        docs?: T | undefined;
+        limit?: T | undefined;
+        page?: T | undefined;
+        nextPage?: T | undefined;
+        prevPage?: T | undefined;
+        hasNextPage?: T | undefined;
+        hasPrevPage?: T | undefined;
+        totalPages?: T | undefined;
+        pagingCounter?: T | undefined;
+        meta?: T | undefined;
+    }
+
+    interface PaginateOptions {
+        sort?: object | string | undefined;
+        offset?: number | undefined;
+        page?: number | undefined;
+        limit?: number | undefined;
+        customLabels?: CustomLabels | undefined;
+        /* If pagination is set to `false`, it will return all docs without adding limit condition. (Default: `true`) */
+        pagination?: boolean | undefined;
+        allowDiskUse?: boolean | undefined;
+        countQuery?: object | undefined;
+        useFacet?: boolean | undefined;
+    }
+
+    interface QueryPopulateOptions {
+        /** space delimited path(s) to populate */
+        path: string;
+        /** optional fields to select */
+        select?: any;
+        /** optional query conditions to match */
+        match?: any;
+        /** optional model to use for population */
+        model?: string | Model<any> | undefined;
+        /** optional query options like sort, limit, etc */
+        options?: any;
+        /** deep populate */
+        populate?: QueryPopulateOptions | QueryPopulateOptions[] | undefined;
+    }
+
+    interface AggregatePaginateResult<T> {
+        docs: T[];
+        totalDocs: number;
+        limit: number;
+        page?: number | undefined;
+        totalPages: number;
+        nextPage?: number | null | undefined;
+        prevPage?: number | null | undefined;
+        pagingCounter: number;
+        hasPrevPage: boolean;
+        hasNextPage: boolean;
+        meta?: any;
+        [customLabel: string]: T[] | number | boolean | null | undefined;
+    }
+
+    interface AggregatePaginateModel<D> extends Model<D> {
+        aggregatePaginate<T>(
+            query?: Aggregate<T[]>,
+            options?: PaginateOptions,
+            callback?: (err: any, result: AggregatePaginateResult<T>) => void,
+        ): Promise<AggregatePaginateResult<T>>;
+    }
+
+    function model(name: string, schema?: Schema, collection?: string, skipInit?: boolean): AggregatePaginateModel<any>;
+}
+
+import mongoose = require("mongoose");
+
+declare function mongooseAggregatePaginate(schema: mongoose.Schema): void;
+
+export = mongooseAggregatePaginate;
+
+declare namespace mongooseAggregatePaginate {
+    const PREPAGINATION_PLACEHOLDER: string;
+}
+
+declare namespace _ {
+    const aggregatePaginate: { options: mongoose.PaginateOptions };
+}


### PR DESCRIPTION
Hello, this is a solution which I happened to think of while trying to optimize a couple of resource intensive queries. It allows someone to control where exactly in the pipeline should the pagination (skip and limit) should run while preserving the existing behavior of the plugin (Attached below is a test output). Further I believe this addresses the issues #57 and #48.

Please do let me know your thoughts on this if you do find the time. I also added in the type definitions from the https://www.npmjs.com/package/@types/mongoose-aggregate-paginate-v2 package directly into this so that it becomes easier to maintain.

<img width="1440" alt="image" src="https://github.com/aravindnc/mongoose-aggregate-paginate-v2/assets/73662613/4a9d1fcd-67ca-4bcb-8ba8-5107da63868e">
