### PR TITLE
Added match stage before facet to improve performance

### DIFF
--- a/lib/mongoose-aggregate-paginate.js
+++ b/lib/mongoose-aggregate-paginate.js
@@ -89,7 +89,7 @@ function aggregatePaginate(query, options, callback) {
   const allowDiskUse = options.allowDiskUse || false;
   const isPaginationEnabled = options.pagination === false ? false : true;
 
-  const q = this.aggregate();
+  let q = this.aggregate();
 
   if (query.options) q.options = query.options;
 
@@ -125,7 +125,13 @@ function aggregatePaginate(query, options, callback) {
 
   let promise;
   if (options.useFacet && !options.countQuery) {
-    const [pipeline, countPipeline] = constructPipelines();
+    let [pipeline, countPipeline] = constructPipelines();
+    const match = pipeline[0]?.$match;
+    if (match) {
+      pipeline.shift();
+      countPipeline.shift();
+      q = q.match(match);
+    }
     promise = q
       .facet({
         docs: pipeline,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-aggregate-paginate-v2",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A cursor based custom aggregate pagination library for Mongoose with customizable labels.",
   "main": "index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
Hello, I happened to notice that `facet`, if used as the first stage in an aggregate pipeline doesn't use indexes which is a bit problematic. It's described in detail [here.](https://www.mongodb.com/docs/manual/reference/operator/aggregation/facet/#:~:text=The%20%24facet%20stage%20does%20not,trigger%20a%20COLLSCAN%20during%20execution)

This pr extracts the match stage from the pipeline and adds it before the facet which solves this issue