### PR TITLE
fix: non-facet aggregations use correct countQuery to get total numbe…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ typings/
 .next
 
 dist
+.idea/

--- a/lib/mongoose-aggregate-paginate.js
+++ b/lib/mongoose-aggregate-paginate.js
@@ -142,7 +142,9 @@ function aggregatePaginate(query, options, callback) {
   } else {
     const [pipeline, countPipeline] = constructPipelines();
 
-    const countQuery = options.countQuery ? options.countQuery : countPipeline;
+    const countQuery = options.countQuery
+      ? options.countQuery
+      : this.aggregate(countPipeline);
 
     if (allowDiskUse) {
       countQuery.allowDiskUse(true);

--- a/lib/mongoose-aggregate-paginate.js
+++ b/lib/mongoose-aggregate-paginate.js
@@ -102,7 +102,9 @@ function aggregatePaginate(query, options, callback) {
   }
 
   function constructPipelines() {
-    let cleanedPipeline = pipeline.filter((stage) => stage !== PREPAGINATION_PLACEHOLDER);
+    let cleanedPipeline = pipeline.filter(
+      (stage) => stage !== PREPAGINATION_PLACEHOLDER
+    );
 
     const countPipeline = [...cleanedPipeline, { $count: "count" }];
 
@@ -122,7 +124,6 @@ function aggregatePaginate(query, options, callback) {
     return [cleanedPipeline, countPipeline];
   }
 
-
   let promise;
   if (options.useFacet && !options.countQuery) {
     let [pipeline, countPipeline] = constructPipelines();
@@ -135,14 +136,13 @@ function aggregatePaginate(query, options, callback) {
     promise = q
       .facet({
         docs: pipeline,
-        count: countPipeline
+        count: countPipeline,
       })
       .then(([{ docs, count }]) => [docs, count]);
   } else {
+    const [pipeline, countPipeline] = constructPipelines();
 
-    const [pipeline] = constructPipelines();
-
-    const countQuery = options.countQuery ? options.countQuery : this.aggregate(pipeline);
+    const countQuery = options.countQuery ? options.countQuery : countPipeline;
 
     if (allowDiskUse) {
       countQuery.allowDiskUse(true);

--- a/tests/index.js
+++ b/tests/index.js
@@ -267,6 +267,45 @@ describe("mongoose-paginate", function () {
         expect(result.pageCount).to.equal(5);
       });
     });
+
+    it("without facet", () => {
+      // part of the reason for this test is due to working the usage of $search in the aggregation pipeline which is
+      // not supported with facets. The building of a query without facets previously had a bug that meant the pagination
+      // details were based on a single page of results, rather than the full count of results from a pipeline. While
+      // this is a basic test it verifies the pagination still returns the correct result while not using facets.
+      var aggregate = Book.aggregate([
+        {
+          $match: {
+            title: {
+              $in: [/Book/i],
+            },
+          },
+        },
+        {
+          $sort: {
+            date: 1,
+          },
+        },
+      ]);
+      var options = {
+        limit: 10,
+        page: 2,
+        useFacet: false,
+      };
+      return Book.aggregatePaginate(aggregate, options).then((result) => {
+        expect(result.docs).to.have.length(10);
+        expect(result.docs[0].title).to.equal("Book #41");
+        expect(result.totalDocs).to.equal(100);
+        expect(result.limit).to.equal(10);
+        expect(result.page).to.equal(2);
+        expect(result.pagingCounter).to.equal(41);
+        expect(result.hasPrevPage).to.equal(true);
+        expect(result.hasNextPage).to.equal(true);
+        expect(result.prevPage).to.equal(1);
+        expect(result.nextPage).to.equal(3);
+        expect(result.totalPages).to.equal(10);
+      });
+    });
   });
 
   after(async function () {


### PR DESCRIPTION
…r of documents.

Fixes issues where `useFacet` cannot be true (e.g. use of `$search` in a pipeline) returning only a single page of results as seen #60