### PR TITLE
Added prepaginate string type support for TypeScript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,8 @@
 // and LiRen Tu <https://github.com/tuliren> for their contribution
 
 declare module "mongoose" {
+    type PrePaginatePipelineStage = PipelineStage | '__PREPAGINATE__';
+    
     interface CustomLabels<T = string | undefined | boolean> {
         totalDocs?: T | undefined;
         docs?: T | undefined;
@@ -64,7 +66,7 @@ declare module "mongoose" {
 
     interface AggregatePaginateModel<D> extends Model<D> {
         aggregatePaginate<T>(
-            query?: Aggregate<T[]>,
+            query?: Aggregate<T[]> | PrePaginatePipelineStage[],
             options?: PaginateOptions,
             callback?: (err: any, result: AggregatePaginateResult<T>) => void,
         ): Promise<AggregatePaginateResult<T>>;


### PR DESCRIPTION
As per the Readme, you can use `__PREPAGINATE__` in the pipeline and pass that pipeline directly into the `aggregatePaginate` function but the issue is that the query only supports `Aggregate` which is not suitable for the pipeline so it gives the typescript error, so I added new type called `PrePaginatePipelineStage` in query.